### PR TITLE
Update: for new binary naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 __GitHub Action to setup the [Fortran Package Manager](https://github.com/fortran-lang/fpm) on Ubuntu, MacOS and Windows.__
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Github actions](https://github.com/LKedward/setup-fpm/workflows/.github/workflows/test-workflow.yml/badge.svg?event=push)](https://github.com/LKedward/setup-fpm/actions)
+[![Github actions](https://github.com/fortran-lang/setup-fpm/workflows/.github/workflows/test-workflow.yml/badge.svg?event=push)](https://github.com/fortran-lang/setup-fpm/actions)
 
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,8 @@ inputs:
     description: 'API token needed to fetch latest fpm version'
     required: false
     default: 'none'
-  use-bootstrap:
-    description: 'Whether to use the bootstrap implementation of fpm'
+  use-haskell:
+    description: 'Whether to use the legacy Haskell implementation of fpm'
     required: false
     default: false
   fpm-version:

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ async function main(){
     // Get inputs
     const token = core.getInput('github-token');
 
-    const useBootstrap = core.getInput('use-bootstrap').toLowerCase() === 'true';
-    console.log(`use-boostrap: ${useBootstrap}`);
+    const useHaskell = core.getInput('use-haskell').toLowerCase() === 'true';
+    console.log(`use-haskell: ${useHaskell}`);
 
     fpmVersion = core.getInput('fpm-version');
     console.log(`fpm-version: ${fpmVersion}`);
@@ -44,7 +44,7 @@ async function main(){
 
     // Build download path
     const fetchPath = fpmRepo + '/releases/download/' + fpmVersion + '/';
-    const filename = getFPMFilename(useBootstrap,fpmVersion,process.platform);
+    const filename = getFPMFilename(useHaskell,fpmVersion,process.platform);
 
     console.log(`This platform is ${process.platform}`);
     console.log(`Fetching fpm from ${fetchPath}${filename}`)
@@ -96,21 +96,21 @@ async function main(){
 
 // Construct the filename for an fpm release
 //
-//  fpm-[bootstrap-]<version>-<os>-<arch>[.exe]
+//  fpm-[haskell-]<version>-<os>-<arch>[.exe]
 //
-//  <version> is a string of form vX.Y.Z corresponding to a release of fpm
-//  <os> is either 'linux', 'darwin', or 'win32' (as returned by process.platform)
+//  <version> is a string of form X.Y.Z corresponding to a release of fpm
+//  <os> is either 'linux', 'macos', or 'windows'
 //  <arch> here is always 'x86_64'
 //
-function getFPMFilename(useBootstrap,fpmVersion,platform){
+function getFPMFilename(useHaskell,fpmVersion,platform){
 
   filename = 'fpm-';
 
-  if (useBootstrap) {
-    filename += 'bootstrap-';
+  if (useHaskell) {
+    filename += 'haskell-';
   }
 
-  filename += fpmVersion + '-';
+  filename += fpmVersion.replace('v','') + '-';
   
   if (platform === 'linux') {
 


### PR DESCRIPTION
See <https://github.com/fortran-lang/fpm/issues/276>

Modified workflow has been tested [here](https://github.com/LKedward/fhash/actions/runs/410934209).

To be merged after: <https://github.com/fortran-lang/fpm/pull/285>.

After merging, binaries in existing releases will be renamed manually to conform to the new convention.