### PR TITLE
Fix Latest Option

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -7,7 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        use-bootstrap: [false, true]
         fpm-version: ['v0.1.0','v0.1.1','latest']
 
     steps:
@@ -19,7 +18,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fpm-version: ${{ matrix.fpm-version }}
-          use-haskell: ${{ matrix.use-bootstrap }}
 
       - name: test fpm
         run: fpm --help

--- a/README.md
+++ b/README.md
@@ -30,6 +30,4 @@ __`github-token`__ (*only needed if `fpm-version` is `'latest'` or not specified
 __`fpm-version`__ (*optional,default:*`'latest'`) the tag corresponding a Github release from which to fetch the `fpm` binary.
   - If set to `'latest'` (_default_) then the latest `fpm` release at [fortran-lang/fpm](https://github.com/fortran-lang/fpm/releases/latest) will be substituted. `github-token` must be provided if `fpm-version` is `'latest'`.
 
-__`use-haskell`__ (*optional,default:*`false`) whether to fetch and use the legacy Haskell implementation
-
 __`fpm-repository`__ (*optional, default:* `https://github.com/fortran-lang/fpm`) which Github fork to fetch release binaries from.

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,6 @@ inputs:
     description: 'API token needed to fetch latest fpm version'
     required: false
     default: 'none'
-  use-haskell:
-    description: 'Whether to use the legacy Haskell implementation of fpm'
-    required: false
-    default: false
   fpm-version:
     description: 'The tag of an fpm release'
     required: false

--- a/index.js
+++ b/index.js
@@ -14,9 +14,6 @@ async function main(){
     // Get inputs
     const token = core.getInput('github-token');
 
-    const useHaskell = core.getInput('use-haskell').toLowerCase() === 'true';
-    console.log(`use-haskell: ${useHaskell}`);
-
     var fpmVersion = core.getInput('fpm-version');
     console.log(`fpm-version: ${fpmVersion}`);
 
@@ -44,7 +41,7 @@ async function main(){
 
     // Build download path
     const fetchPath = fpmRepo + '/releases/download/' + fpmVersion + '/';
-    const filename = getFPMFilename(useHaskell,fpmVersion,process.platform);
+    const filename = getFPMFilename(fpmVersion,process.platform);
 
     console.log(`This platform is ${process.platform}`);
     console.log(`Fetching fpm from ${fetchPath}${filename}`);
@@ -96,19 +93,15 @@ async function main(){
 
 // Construct the filename for an fpm release
 //
-//  fpm-[haskell-]<version>-<os>-<arch>[.exe]
+//  fpm-<version>-<os>-<arch>[.exe]
 //
 //  <version> is a string of form X.Y.Z corresponding to a release of fpm
 //  <os> is either 'linux', 'macos', or 'windows'
 //  <arch> here is always 'x86_64'
 //
-function getFPMFilename(useHaskell,fpmVersion,platform){
+function getFPMFilename(fpmVersion,platform){
 
   var filename = 'fpm-';
-
-  if (useHaskell) {
-    filename += 'haskell-';
-  }
 
   filename += fpmVersion.replace('v','') + '-';
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ async function main(){
 
     // Get latest version if requested
     if (fpmVersion === 'latest'){
-     
+
       if (token === 'none') {
         core.setFailed('To fetch the latest fpm version, please supply a github token. Alternatively you can specify the fpm release version manually.');
       }
@@ -48,48 +48,48 @@ async function main(){
 
     console.log(`This platform is ${process.platform}`);
     console.log(`Fetching fpm from ${fetchPath}${filename}`);
-    
+
     // Download release
     var fpmPath;
     try {
-    
+
       fpmPath = await tc.downloadTool(fetchPath+filename);
-    
+
     } catch (error) {
-      
+
       core.setFailed(`Error while trying to fetch fpm - please check that a version exists at the above release url.`);
-    
+
     }
 
     console.log(fpmPath);
     const downloadDir = path.dirname(fpmPath);
-    
+
     // Add executable flag on unix
     if (process.platform === 'linux' || process.platform === 'darwin'){
-      
+
       await exec.exec('chmod u+x '+fpmPath);
 
     }
 
     // Rename to 'fpm'
     if (process.platform === 'win32') {
-      
+
       await io.mv(fpmPath, downloadDir + '/' + 'fpm.exe');
 
     } else {
-      
+
       await io.mv(fpmPath, downloadDir + '/' + 'fpm');
 
     }
-    
+
     // Add to path
     core.addPath( downloadDir );
     console.log(`fpm added to path at ${downloadDir}`);
-    
+
   } catch (error) {
 
     core.setFailed(error.message);
-    
+
   }
 };
 
@@ -111,7 +111,7 @@ function getFPMFilename(useHaskell,fpmVersion,platform){
   }
 
   filename += fpmVersion.replace('v','') + '-';
-  
+
   if (platform === 'linux') {
 
     filename += 'linux-x86_64';
@@ -137,14 +137,14 @@ function getFPMFilename(useHaskell,fpmVersion,platform){
 // Query github API to find the tag for the latest release
 //
 async function getLatestReleaseVersion(token){
-  
-  const octokit = github.getOctokit(token);
-  
-  const {data: releases} = await octokit.repos.listReleases({
-                            owner:'fortran-lang',
-                            repo:'fpm'});
 
-  return releases[0].tag_name;
+  const octokit = github.getOctokit(token);
+
+  const {data: latest} = await octokit.request('GET /repos/{owner}/{repo}/releases/latest', {
+                            owner: 'fortran-lang',
+                            repo: 'fpm'});
+
+  return latest.tag_name;
 
 }
 


### PR DESCRIPTION
Fix how we retrieve the latest release version. The new "current" version broke the existing logic.

Also, remove the Haksell option, since the releases no longer include a binary for it.

Fix #7 