### PR TITLE
Update to v4 in usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ __GitHub Action to setup the [Fortran Package Manager](https://github.com/fortra
 ## Usage
 
 ```yaml
-  - uses: fortran-lang/setup-fpm@v3
+  - uses: fortran-lang/setup-fpm@v4
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
After some painful CI troubleshooting I noticed that I was not using the latest version of setup-fpm. The version in the usage example is here updated from "v3" to "v4"