### PR TITLE
ci: test that setup-fpm passes all the fpm tests

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -41,6 +41,13 @@ jobs:
         with:
           repository: fortran-lang/fpm
 
+      - name: Setup the Fortran compiler
+        if: matrix.fpm-version == 'latest'
+        uses: fortran-lang/setup-fortran@v1.6.1
+        with:
+          compiler: gcc
+          compiler-version: 13
+
       - name: Check that all the fpm tests pass
         if: matrix.fpm-version == 'latest'
         run: fpm test

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -35,5 +35,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fpm-version: ${{ matrix.fpm-version }}
 
-      - name: test fpm
-        run: fpm --help
+      - name: Checkout the fpm repo
+        if: matrix.fpm-version == 'latest'
+        uses: actions/checkout@v4
+        with:
+          repository: fortran-lang/fpm
+
+      - name: Check that all the fpm tests pass
+        if: matrix.fpm-version == 'latest'
+        run: fpm test


### PR DESCRIPTION
Fixes #9 

I thought it would be quite appropriate (and somewhat funny) to check that `fpm-setup` works by running the fpm test suite.