### PR TITLE
Search compiler-specific fpm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ __`fpm-repository`__ (*optional, default:* `https://github.com/fortran-lang/fpm`
 
 ### Default `fpm-version` for Each Release
 
-Starting with `v7`, `setup-fpm` is pinpointed to `fpm` version `0.11.0` to ensure compatibility with newer features and changes. 
+Starting with `v7`, `setup-fpm` is pinpointed to `fpm` version `v0.11.0` to ensure compatibility with newer features and changes. 
 Previous versions default to the latest stable release, which is fetched automatically when `fpm-version` is set to `'latest'`.
 
 | Release Version | Default `fpm-version` |
@@ -48,3 +48,4 @@ Previous versions default to the latest stable release, which is fetched automat
 | v6.1.0          | latest                |
 | v7              | 0.11.0                |
 
+Note: `fpm` changed asset naming convention starting version `v0.11.0`. So, the `latest` option will not work anymore with versions of `setup-fpm` prior to `v7`. 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,25 @@ __e.g.:__
 
 __`github-token`__ (*only needed if `fpm-version` is `'latest'` or not specified*), an access token used to query the latest version of `fpm`. Set to `${{ secrets.GITHUB_TOKEN }}` to use the existing github actions token.
 
-__`fpm-version`__ (*optional,default:*`'latest'`) the tag corresponding a Github release from which to fetch the `fpm` binary.
-  - If set to `'latest'` (_default_) then the latest `fpm` release at [fortran-lang/fpm](https://github.com/fortran-lang/fpm/releases/latest) will be substituted. `github-token` must be provided if `fpm-version` is `'latest'`.
+__`fpm-version`__ (*optional, default:* see below) the tag corresponding to a Github release from which to fetch the `fpm` binary.
+  - If set to `'latest'` then the latest `fpm` release at [fortran-lang/fpm](https://github.com/fortran-lang/fpm/releases/latest) will be substituted. `github-token` must be provided if `fpm-version` is `'latest'`.
 
 __`fpm-repository`__ (*optional, default:* `https://github.com/fortran-lang/fpm`) which Github fork to fetch release binaries from.
+
+### Default `fpm-version` for Each Release
+
+Starting with `v7`, `setup-fpm` is pinpointed to `fpm` version `0.11.0` to ensure compatibility with newer features and changes. 
+Previous versions default to the latest stable release, which is fetched automatically when `fpm-version` is set to `'latest'`.
+
+| Release Version | Default `fpm-version` |
+|-----------------|-----------------------|
+| v1              | latest                |
+| v2              | latest                |
+| v3              | latest                |
+| v4              | latest                |
+| v5              | latest                |
+| v6.0.1          | latest                |
+| v6              | latest                |
+| v6.1.0          | latest                |
+| v7              | 0.11.0                |
+

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   fpm-version:
     description: 'The tag of an fpm release'
     required: false
-    default: 'latest'
+    default: 'v0.11.0'
   fpm-repository:
     description: 'Github repository (url) serving fpm releases'
     required: false

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ async function main(){
       for (const compiler of compilers) {
             
         // Generate the filename with the compiler suffix
-        const filenameWithSuffix = getFPMFilename(fpmVersion, process.platform, compilers);
+        const filenameWithSuffix = getFPMFilename(fpmVersion, process.platform, compiler);
         console.log(`Trying to fetch compiler-built fpm: ${filenameWithSuffix}`);
 
         try {

--- a/index.js
+++ b/index.js
@@ -44,13 +44,13 @@ async function main(){
     const filename = getFPMFilename(fpmVersion,process.platform);
 
     console.log(`This platform is ${process.platform}`);    
+    console.log(`Fetching fpm from ${fetchPath}${filename}`);
 
     // Download release
     var fpmPath;
     try {
         
-      // Try downloading the file without the compiler suffix
-      console.log(`Fetching fpm from ${fetchPath}${filename}`);
+      // Try downloading the file without the compiler suffix      
       const filename = getFPMFilename(fpmVersion, process.platform);
       fpmPath = await tc.downloadTool(fetchPath + filename);
 


### PR DESCRIPTION
Attempt to fix #37  https://github.com/fortran-lang/fpm/issues/1104

fpm release assets were changed naming in https://github.com/fortran-lang/fpm/pull/985.

@gnikit should we bump the release version after this? Otherwise, people won't be able to use `fpm 0.11.0` and in general  those using `latest` wuold break their CIs.