### PR TITLE
Readme should recommend v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ __GitHub Action to setup the [Fortran Package Manager](https://github.com/fortra
 ## Usage
 
 ```yaml
-  - uses: fortran-lang/setup-fpm@v5
+  - uses: fortran-lang/setup-fpm@v7
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
This avoids UX confusion with the older setup-fpm, which break every time a new "latest" FPM is released.

Ref: #41 