### PR TITLE
Upgrade action runtime and pinned actions to Node.js 24

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//Users/federico/code/fpm/**)",
+      "Bash(node:*)",
+      "Bash(gh release view:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       - name: MacOS system setup
         if: runner.os == 'macOS'
         run: |
-          brew install gcc@13
+          brew install gcc@12
 
       - name: Install dependencies
         run: npm ci
@@ -43,10 +43,10 @@ jobs:
 
       - name: Setup the Fortran compiler
         if: matrix.fpm-version == 'latest'
-        uses: fortran-lang/setup-fortran@v1.6.3
+        uses: fortran-lang/setup-fortran@v1.9.0
         with:
           compiler: gcc
-          version: 13
+          version: 12
 
       - name: Check that all the fpm tests pass
         if: matrix.fpm-version == 'latest'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: MacOS system setup
         if: runner.os == 'macOS'
+        # fpm binaries are currently built and linking against gfortran-12 runtime on macOS
         run: |
           brew install gcc@12
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -10,14 +10,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, macos-15, windows-latest]
         fpm-version: ["v0.9.0", "v0.10.1", "v0.11.0", "v0.12.0", "latest", "current"]
-        node-version: ["20.x"]
+        node-version: ["24.x"]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout the fpm repo
         if: matrix.fpm-version == 'latest'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: fortran-lang/fpm
 

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     required: false
     default: 'https://github.com/fortran-lang/fpm'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
- Bump this action's own runtime in `action.yml` from `node20` to `node24`.
- Upgrade `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` in the test workflow (both ship on Node 24).
- Update the test matrix `node-version` from `20.x` to `24.x`.