### PR TITLE
Pin default fpm-version to v0.13.0 for v10 release

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, macos-15, windows-latest]
-        fpm-version: ["v0.9.0", "v0.10.1", "v0.11.0", "v0.12.0", "latest", "current"]
+        fpm-version: ["v0.9.0", "v0.10.1", "v0.11.0", "v0.12.0", "v0.13.0", "latest", "current"]
         node-version: ["24.x"]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ __GitHub Action to setup the [Fortran Package Manager](https://github.com/fortra
 ## Usage
 
 ```yaml
-  - uses: fortran-lang/setup-fpm@v7
+  - uses: fortran-lang/setup-fpm@v10
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -34,7 +34,7 @@ __`fpm-repository`__ (*optional, default:* `https://github.com/fortran-lang/fpm`
 
 ### Default `fpm-version` for Each Release
 
-Starting with `v7`, `setup-fpm` is pinpointed to `fpm` version `v0.11.0` to ensure compatibility with newer features and changes. 
+Starting with `v7`, `setup-fpm` is pinpointed to a specific `fpm` version to ensure compatibility with newer features and changes. From `v10`, the default is pinned to `v0.13.0`. 
 Previous versions default to the latest stable release, which is fetched automatically when `fpm-version` is set to `'latest'`.
 
 | Release Version | Default `fpm-version` |
@@ -50,5 +50,6 @@ Previous versions default to the latest stable release, which is fetched automat
 | v7              | 0.11.0                |
 | v8              | 0.11.0                |
 | v9              | 0.12.0                |
+| v10             | 0.13.0                |
 
 Note: `fpm` changed asset naming convention starting version `v0.11.0`. So, the `latest` option will not work anymore with versions of `setup-fpm` prior to `v7`. 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   fpm-version:
     description: 'The tag of an fpm release'
     required: false
-    default: 'v0.12.0'
+    default: 'v0.13.0'
   fpm-repository:
     description: 'Github repository (url) serving fpm releases'
     required: false


### PR DESCRIPTION
- Bump default `fpm-version` from `v0.12.0` to `v0.13.0`, in preparation for the upcoming `setup-fpm@v10` release.
- Update README accordingly