### PR TITLE
Build from source on Linux ARM64 too

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -52,3 +52,43 @@ jobs:
       - name: Check that all the fpm tests pass
         if: matrix.fpm-version == 'latest'
         run: fpm test
+
+  # There is no linux-arm64 release asset, so every download in the action fails
+  # on this runner and only the build-from-source fallback can install fpm. Kept
+  # as a separate job with one version, because each run compiles fpm. See #60.
+  Test-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        fpm-version: ["v0.13.0"]
+        node-version: ["24.x"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install gfortran
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran-13
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: fpm-setup
+        uses: ./ # Uses action in the root directory
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fpm-version: ${{ matrix.fpm-version }}
+
+      - name: Check that fpm runs
+        run: |
+          fpm --version
+          fpm new demo --app
+          cd demo && fpm run

--- a/index.js
+++ b/index.js
@@ -83,9 +83,13 @@ async function main(){
       }
 
       if (!success) {
-        // On macOS ARM64, fall back to building from source
-        if (process.platform === 'darwin' && arch === 'arm64') {
-          console.log('No pre-built ARM64 binary found, falling back to building from source');
+        // Not every platform and architecture has a pre-built binary: there is
+        // no linux-arm64 release asset, so on those runners every download above
+        // fails. install.sh makes no assumption about the platform beyond a
+        // POSIX shell and a Fortran compiler, so the same fallback that serves
+        // macOS ARM64 serves Linux ARM64 too. See issue #60.
+        if ((process.platform === 'darwin' || process.platform === 'linux') && arch === 'arm64') {
+          console.log(`No pre-built ${process.platform}-${arch} binary found, falling back to building from source`);
 
           // For older versions without working install.sh, we can't build from source
           const versionNum = fpmVersion.replace('v', '');
@@ -94,7 +98,7 @@ async function main(){
 
           if (isOldVersion) {
             core.setFailed(
-              `Building fpm ${fpmVersion} from source is not supported on macOS ARM64.\n` +
+              `Building fpm ${fpmVersion} from source is not supported on ${process.platform} ${arch}.\n` +
               'Please use fpm v0.9.0 or later, which has a working install.sh script.\n' +
               'For example, set fpm-version to "v0.9.0", "v0.10.1" or "latest".'
             );
@@ -105,7 +109,11 @@ async function main(){
           return;
         }
 
-        core.setFailed(`Error while trying to fetch fpm - please check that a version exists at the above release url.`);
+        // Without this return, execution carried on to path.dirname(fpmPath)
+        // with fpmPath still undefined, and the real reason was buried under a
+        // second, unrelated error: 'The "path" argument must be of type string'.
+        core.setFailed(`Error while trying to fetch fpm ${fpmVersion} for ${process.platform}-${arch} - no release asset was found for this platform and it could not be built from source.`);
+        return;
       }
     }
 
@@ -203,7 +211,8 @@ async function getLatestReleaseVersion(token){
 
 
 // Install fpm from source using the install.sh script
-// This is used on macOS ARM64 where pre-built binaries are not available
+// This is used on the platforms where pre-built binaries are not available,
+// currently macOS ARM64 and Linux ARM64
 //
 async function installFromSource(fpmVersion, fpmRepo){
 
@@ -238,11 +247,14 @@ async function installFromSource(fpmVersion, fpmRepo){
     }
 
     if (!foundVersioned && !foundGfortran) {
+      const installHint = process.platform === 'darwin'
+        ? '    run: brew install gcc@13\n'
+        : '    run: sudo apt-get install -y gfortran-13\n';
       core.setFailed(
-        'gfortran is required to build fpm from source on macOS ARM64.\n' +
+        `gfortran is required to build fpm from source on ${process.platform} ${os.arch()}.\n` +
         'Please install gcc version 10-13 before running this action, for example:\n' +
         '  - name: Install gfortran\n' +
-        '    run: brew install gcc@13\n' +
+        installHint +
         'Or use fortran-lang/setup-fortran to install a Fortran compiler.'
       );
       return;


### PR DESCRIPTION
Answering the question in #60 — *"shouldn't there be an automatic fallback to build from source, and if so why isn't that working?"*

There is one, and it is gated on macOS:

```js
if (process.platform === 'darwin' && arch === 'arm64') {
```

So on an ARM64 Linux runner it never runs. fpm publishes no `linux-arm64` asset — confirmed against the v0.13.0 release, which has `linux-x86_64`, `macos-arm64`, `macos-x86_64` and `windows-x86_64` and nothing else — so all six URLs the action tries return 404, on real hardware:

```
404  fpm-0.13.0-linux-arm64
404  fpm-0.13.0-linux-arm64-gcc-10 .. gcc-14
```

and the action stops with `Error while trying to fetch fpm - please check that a version exists at the above release url`, which points at the version rather than at the missing architecture.

### What this changes

`install.sh` makes no assumption about the platform beyond a POSIX shell and a Fortran compiler — no `uname`, no OS branching — it bootstraps from the single-file `fpm-0.8.0.F90` and builds the requested version with it. The same fallback that serves macOS ARM64 serves Linux ARM64, so the gate is widened to cover it and the messages now name the platform they are running on instead of hardcoding macOS and `brew`.

It also adds a `return` after that `setFailed`. Execution carried on to `path.dirname(fpmPath)` with `fpmPath` still undefined, so the real reason was buried under a second, unrelated error — visible in the screenshot on the issue:

```
The "path" argument must be of type string. Received undefined
```

### Verification

Run on an Ubuntu 26.04 aarch64 VM by executing the action itself, not a simulation of it:

| | result |
|---|---|
| `main` | exit 1, no fpm, both errors above |
| this branch | exit 0, `No pre-built linux-arm64 binary found, falling back to building from source`, `fpm installed and added to path at ~/.local/bin` |

The installed binary is `ELF 64-bit LSB pie executable, ARM aarch64`, reports `Version: 0.13.0, alpha`, and `fpm new demo --app && fpm run` prints `hello from project demo`.

macOS ARM64 is unaffected — checked on an arm64 Mac, where `fpm-0.13.0-macos-arm64-gcc-12` still downloads and the fallback is never reached.

The new `Test-linux-arm64` job covers this on `ubuntu-24.04-arm`. I kept it out of the main matrix and pinned it to one version, because each run compiles fpm and multiplying it across the seven versions would be a lot of CI time for the same signal — happy to fold it into the matrix instead if you would rather have the coverage.

Note this does not remove the need for [fortran-lang/fpm#1282](https://github.com/fortran-lang/fpm/issues/1282); a published `linux-arm64` binary would still be faster than building. This makes the runner work in the meantime.

Fixes #60
